### PR TITLE
removed ref to 'src'

### DIFF
--- a/week2/readme.md
+++ b/week2/readme.md
@@ -35,7 +35,7 @@ npm install
 ```
 
 ## Serve a static page
-1. Create a "public" directory inside the `src` directory
+1. Create a "public" directory
 ```
 mkdir public
 ```


### PR DESCRIPTION
'public' is located outside of 'src' in week2 to week8

not sure if this is actually an error, but "public" is located outside of "src" in each week